### PR TITLE
Port from libunique to GApplication and GtkApplication

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -61,7 +61,6 @@ case "$with_gtk" in
   3.0) GTK_API_VERSION=3.0
        GTK_REQUIRED_VERSION=3.0.0
        CANBERRA_API_VERSION=3
-       UNIQUE_API_VERSION=3.0
        ;;
 esac
 
@@ -71,16 +70,28 @@ dnl=======================================================================
 dnl Check for the volume control modules
 dnl=======================================================================
 
-PKG_CHECK_MODULES(VOLUME_CONTROL,
-                  gobject-2.0 >= $GLIB_REQUIRED_VERSION
-                  gtk+-$GTK_API_VERSION >= $GTK_REQUIRED_VERSION
-                  gio-2.0 >= $GIO_REQUIRED_VERSION
-                  libcanberra-gtk$CANBERRA_API_VERSION >= $CANBERRA_REQUIRED_VERSION
-                  unique-$UNIQUE_API_VERSION
-                  libxml-2.0
-                  mate-desktop-2.0 >= $MATE_DESKTOP_REQUIRED_VERSION
-                  libmatemixer >= $MATE_MIXER_REQUIRED_VERSION
-)
+if test "$GTK_API_VERSION" = "3.0"; then
+        PKG_CHECK_MODULES(VOLUME_CONTROL,
+                          gobject-2.0 >= $GLIB_REQUIRED_VERSION
+                          gtk+-$GTK_API_VERSION >= $GTK_REQUIRED_VERSION
+                          gio-2.0 >= $GIO_REQUIRED_VERSION
+                          libcanberra-gtk$CANBERRA_API_VERSION >= $CANBERRA_REQUIRED_VERSION
+                          libxml-2.0
+                          mate-desktop-2.0 >= $MATE_DESKTOP_REQUIRED_VERSION
+                          libmatemixer >= $MATE_MIXER_REQUIRED_VERSION
+        )
+else
+        PKG_CHECK_MODULES(VOLUME_CONTROL,
+                          gobject-2.0 >= $GLIB_REQUIRED_VERSION
+                          gtk+-$GTK_API_VERSION >= $GTK_REQUIRED_VERSION
+                          gio-2.0 >= $GIO_REQUIRED_VERSION
+                          libcanberra-gtk$CANBERRA_API_VERSION >= $CANBERRA_REQUIRED_VERSION
+                          unique-$UNIQUE_API_VERSION
+                          libxml-2.0
+                          mate-desktop-2.0 >= $MATE_DESKTOP_REQUIRED_VERSION
+                          libmatemixer >= $MATE_MIXER_REQUIRED_VERSION
+        )
+fi
 AC_SUBST(VOLUME_CONTROL_CFLAGS)
 AC_SUBST(VOLUME_CONTROL_LIBS)
 

--- a/mate-volume-control/applet-main.c
+++ b/mate-volume-control/applet-main.c
@@ -27,7 +27,7 @@
 #include <gtk/gtk.h>
 
 #include <libintl.h>
-#include <unique/uniqueapp.h>
+#include <gio/gio.h>
 #include <libmatemixer/matemixer.h>
 
 #include "gvc-applet.h"
@@ -40,7 +40,7 @@ main (int argc, char **argv)
 {
         GError       *error = NULL;
         GvcApplet    *applet;
-        UniqueApp    *app;
+	GApplication       *app = NULL;
         GOptionEntry  entries[] = {
                 { "version", 'v', 0, G_OPTION_ARG_NONE, &show_version, N_("Version of this application"), NULL },
                 { "debug", 'd', 0, G_OPTION_ARG_NONE, &debug, N_("Enable debug"), NULL },
@@ -58,6 +58,7 @@ main (int argc, char **argv)
 
         if (error != NULL) {
                 g_warning ("%s", error->message);
+		g_error_free (error);
                 return 1;
         }
         if (show_version == TRUE) {
@@ -68,9 +69,14 @@ main (int argc, char **argv)
                 g_setenv ("G_MESSAGES_DEBUG", "all", FALSE);
         }
 
-        app = unique_app_new (GVC_APPLET_DBUS_NAME, NULL);
+	app = g_application_new (GVC_APPLET_DBUS_NAME, G_APPLICATION_FLAGS_NONE);
 
-        if (unique_app_is_running (app) == TRUE) {
+	if (!g_application_register (app, NULL, &error)) {
+		g_warning ("%s", error->message);
+		g_error_free (error);
+		return 1;
+	}
+	if (g_application_get_is_remote (app)) {
                 g_warning ("Applet is already running, exiting");
                 return 0;
         }


### PR DESCRIPTION
Merging this into my own branch so I have a source for mate-media 1.16 with this

applet-main.c: gtk2 and gtk3

```
Port to Gapplication based on this gnome-media commits:
https://github.com/GNOME/gnome-media/commit/7b5a8127cea09779dd172b0b7598d2ad03b2e47b
https://github.com/GNOME/gnome-media/commit/7283e156e0ea1b2d19292a97104b3ad49fc9e693
```

dialog-main.c: gtk3

```
Port to Gapplication and GtkApplication
I did this implementation
```

Fixes #77
